### PR TITLE
Create a new hash object for each trap

### DIFF
--- a/lib/fluent/plugin/in_snmptrapalert.rb
+++ b/lib/fluent/plugin/in_snmptrapalert.rb
@@ -53,9 +53,9 @@ module Fluent
                 #Start Listening to SNMP Traps
                 def start
                     super
-                    trap_events = Hash.new
                     @snmptrap = SNMP::TrapListener.new(:Host => @host, :Port => @port) do |manager|
                         manager.on_trap_default do |trap|
+                            trap_events = Hash.new
                             tag = @tag
                             timestamp = Engine.now
                             raise("Unknown Trap Format", trap) unless trap.kind_of?(SNMP::SNMPv1_Trap) or trap.kind_of?(SNMP::SNMPv2_Trap)


### PR DESCRIPTION
Previously, the code was reusing the same hash object every time there
was a new trap. If the Hash is modified on the subsequent plugins, the
modification gets preserved for the next trap. That's undesired
behavior.

With this change, a new Hash object gets created every time a new trap
comes to fluentd. So, any modification to it will not affect other
events.