### PR TITLE
Add additional fields to trap events for snmpv1

### DIFF
--- a/lib/fluent/plugin/in_snmptrapalert.rb
+++ b/lib/fluent/plugin/in_snmptrapalert.rb
@@ -93,6 +93,9 @@ module Fluent
                                 trap_events[vb.name.to_s] = vb.value.to_s
                             end
                             trap_events['host'] = trap.source_ip
+                            if trap.kind_of?(SNMP::SNMPv1_Trap)
+                                trap_events['specifictrap'] = trap.specific_trap
+                            end
                             if @trap_format == 'tojson'
                                require 'json'
                                trap_events.to_json

--- a/lib/fluent/plugin/in_snmptrapalert.rb
+++ b/lib/fluent/plugin/in_snmptrapalert.rb
@@ -95,7 +95,7 @@ module Fluent
                             trap_events['host'] = trap.source_ip
                             if trap.kind_of?(SNMP::SNMPv1_Trap)
                                 trap_events['specific_trap'] = trap.specific_trap
-                                trap_events['enterprise'] = trap.enterprise          
+                                trap_events['enterprise'] = trap.enterprise
                             end
                             if @trap_format == 'tojson'
                                require 'json'

--- a/lib/fluent/plugin/in_snmptrapalert.rb
+++ b/lib/fluent/plugin/in_snmptrapalert.rb
@@ -94,7 +94,8 @@ module Fluent
                             end
                             trap_events['host'] = trap.source_ip
                             if trap.kind_of?(SNMP::SNMPv1_Trap)
-                                trap_events['specifictrap'] = trap.specific_trap
+                                trap_events['specific_trap'] = trap.specific_trap
+                                trap_events['enterprise'] = trap.enterprise          
                             end
                             if @trap_format == 'tojson'
                                require 'json'

--- a/lib/fluent/plugin/in_snmptrapalert.rb
+++ b/lib/fluent/plugin/in_snmptrapalert.rb
@@ -96,6 +96,7 @@ module Fluent
                             if trap.kind_of?(SNMP::SNMPv1_Trap)
                                 trap_events['specific_trap'] = trap.specific_trap
                                 trap_events['enterprise'] = trap.enterprise
+                                trap_events['generic_trap'] = trap.generic_trap
                             end
                             if @trap_format == 'tojson'
                                require 'json'

--- a/test/plugin/test_in_snmptrapalert.rb
+++ b/test/plugin/test_in_snmptrapalert.rb
@@ -2,118 +2,120 @@ require 'helper'
 
 class SnmptrapalertInputTest < Test::Unit::TestCase
 
-  setup do
-    Fluent::Test.setup
-  end
-
-  SNMP_CONFIG = %[
-    host 0.0.0.0
-    port 1620
-    tag SNMPTrap.Alert
-  ]
-
-  def create_driver(conf=SNMP_CONFIG)
-    Fluent::Test::Driver::Input.new(Fluent::Plugin::SnmpTrapAlert).configure(conf)
-  end
-
-  def send_trap_v1()
-    SNMP::Manager.open(:Host => "127.0.0.1",:TrapPort => 1620, :Version => :SNMPv1) do |snmp|
-      snmp.trap_v1(
-        "1.3.6.1.4.1.10300.1.1.1.12",
-        '172.0.0.1',
-        :enterpriseSpecific, #Generic Trap Type
-        0,
-        1234,
-        [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(1))])
-    end
-  end
-
-  def send_trap_v2()
-    SNMP::Manager.open(:Host => "127.0.0.1",:TrapPort => 1620, :Version => :SNMPv2c) do |snmp|
-      snmp.trap_v2(
-          400, # Fake system up time of 4 seconds
-        "1.3.6.1.4.1.10300.1.1.1.12",
-        [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(1))])
-    end
-  end
-
-  def test_configure
-    driver = create_driver('')
-    assert_equal "0.0.0.0", driver.instance.host
-    assert_equal 162, driver.instance.port
-    assert_equal 'SNMPTrap.Alert', driver.instance.tag
-  end
-
-  def test_configure_custom
-    driver = create_driver(SNMP_CONFIG)
-    assert_equal "0.0.0.0", driver.instance.host
-    assert_equal 1620, driver.instance.port
-    assert_equal 'SNMPTrap.Alert', driver.instance.tag
-  end
-
-  test 'emitv1' do
-    driver = create_driver(SNMP_CONFIG)
-    driver.run(expect_emits: 1, timeout: 5) do
-      send_trap_v1()
-    end
-    assert_equal(driver.events.length(), 1)
-    driver.events.each do |tag, timestamp, trap_events|
-      assert_equal("SNMPTrap.Alert", tag)
-      assert_true(timestamp.is_a?(Fluent::EventTime))
-      assert_equal(trap_events, {"SNMPv2-SMI::mgmt.3.4"=>"1", "enterprise"=>[1,3,6,1,4,1,10300,1,1,1,12],"host"=>"127.0.0.1", "specific_trap"=>0})
-    end
-  end
-
-  test 'emit_mibv1' do
-    driver = create_driver(SNMP_CONFIG)
-    driver.run(expect_emits: 1, timeout: 5) do
-      send_trap_v1()
+    setup do
+        Fluent::Test.setup
     end
 
-    assert_equal(driver.events.length(), 1)
-    driver.events.each do |tag, timestamp, trap_events|
-      assert_equal 'SNMPTrap.Alert', tag
-      assert_true timestamp.is_a?(Fluent::EventTime)
-      message = trap_events.to_s
-      message = message.delete('\\"')
-      assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, message)
+    SNMP_CONFIG = %[
+        host 0.0.0.0
+        port 1620
+        tag SNMPTrap.Alert
+    ]
 
-      trap_events.each do |key, value|
-        assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host)|(specific_trap)|(enterprise))/, key.to_s, "Unknown OID format")
-      end
-    end
-  end
-
-  test 'emitv2' do
-    driver = create_driver(SNMP_CONFIG)
-    driver.run(expect_emits: 1, timeout: 5) do
-      send_trap_v2()
-    end
-    assert_equal(driver.events.length(), 1)
-    driver.events.each do |tag, timestamp, trap_events|
-      assert_equal("SNMPTrap.Alert", tag)
-      assert_true(timestamp.is_a?(Fluent::EventTime))
-      assert_equal(trap_events, {"SNMPv2-MIB::snmpTrapOID.0"=>"SNMPv2-SMI::enterprises.10300.1.1.1.12", "SNMPv2-MIB::sysUpTime.0"=>"00:00:04.00","SNMPv2-SMI::mgmt.3.4"=>"1", "host"=>"127.0.0.1"})
-    end
-  end
-
-  test 'emit_mibv2' do
-    driver = create_driver(SNMP_CONFIG)
-    driver.run(expect_emits: 1, timeout: 5) do
-      send_trap_v2()
+    def create_driver(conf=SNMP_CONFIG)
+        Fluent::Test::Driver::Input.new(Fluent::Plugin::SnmpTrapAlert).configure(conf)
     end
 
-    assert_equal(driver.events.length(), 1)
-    driver.events.each do |tag, timestamp, trap_events|
-      assert_equal 'SNMPTrap.Alert', tag
-      assert_true timestamp.is_a?(Fluent::EventTime)
-      message = trap_events.to_s
-      message = message.delete('\\"')
-      assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, message)
-
-      trap_events.each do |key, value|
-        assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host))/, key.to_s, "Unknown OID format")
-      end
+    def send_trap_v1()
+        SNMP::Manager.open(:Host => "127.0.0.1", :TrapPort => 1620, :Version => :SNMPv1) do |snmp|
+            snmp.trap_v1(
+            "1.3.6.1.4.1.10300.1.1.1.12",
+            '172.0.0.1',
+            :enterpriseSpecific, #Generic Trap Type
+            0,
+            1234,
+            [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(1))])
+        end
     end
-  end
+
+    def send_trap_v2()
+        SNMP::Manager.open(:Host => "127.0.0.1", :TrapPort => 1620, :Version => :SNMPv2c) do |snmp|
+            snmp.trap_v2(
+            400, # Fake system up time of 4 seconds
+            "1.3.6.1.4.1.10300.1.1.1.12",
+            [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(1))])
+        end
+    end
+
+    def test_configure
+        driver = create_driver('')
+        assert_equal "0.0.0.0", driver.instance.host
+        assert_equal 162, driver.instance.port
+        assert_equal 'SNMPTrap.Alert', driver.instance.tag
+    end
+
+    def test_configure_custom
+        driver = create_driver(SNMP_CONFIG)
+        assert_equal "0.0.0.0", driver.instance.host
+        assert_equal 1620, driver.instance.port
+        assert_equal 'SNMPTrap.Alert', driver.instance.tag
+    end
+
+    test 'emit_v1' do
+        driver = create_driver(SNMP_CONFIG)
+        driver.run(expect_emits: 1, timeout: 5) do
+            send_trap_v1()
+        end
+
+        assert_equal(driver.events.length(), 1)
+        driver.events.each do |tag, timestamp, trap_events|
+            assert_equal("SNMPTrap.Alert", tag)
+            assert_true(timestamp.is_a?(Fluent::EventTime))
+            assert_equal(trap_events, {"SNMPv2-SMI::mgmt.3.4"=>"1", "enterprise"=>[1,3,6,1,4,1,10300,1,1,1,12],"host"=>"127.0.0.1", "specific_trap"=>0})
+        end
+    end
+
+    test 'emit_mib_v1' do
+        driver = create_driver(SNMP_CONFIG)
+        driver.run(expect_emits: 1, timeout: 5) do
+            send_trap_v1()
+        end
+
+        assert_equal(driver.events.length(), 1)
+        driver.events.each do |tag, timestamp, trap_events|
+            assert_equal 'SNMPTrap.Alert', tag
+            assert_true timestamp.is_a?(Fluent::EventTime)
+            message = trap_events.to_s
+            message = message.delete('\\"')
+            assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, message)
+
+            trap_events.each do |key, value|
+                assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host)|(specific_trap)|(enterprise))/, key.to_s, "Unknown OID format")
+            end
+        end
+    end
+
+    test 'emit_v2' do
+        driver = create_driver(SNMP_CONFIG)
+        driver.run(expect_emits: 1, timeout: 5) do
+            send_trap_v2()
+        end
+
+        assert_equal(driver.events.length(), 1)
+        driver.events.each do |tag, timestamp, trap_events|
+            assert_equal("SNMPTrap.Alert", tag)
+            assert_true(timestamp.is_a?(Fluent::EventTime))
+            assert_equal(trap_events, {"SNMPv2-MIB::snmpTrapOID.0"=>"SNMPv2-SMI::enterprises.10300.1.1.1.12", "SNMPv2-MIB::sysUpTime.0"=>"00:00:04.00","SNMPv2-SMI::mgmt.3.4"=>"1", "host"=>"127.0.0.1"})
+        end
+    end
+
+    test 'emit_mib_v2' do
+        driver = create_driver(SNMP_CONFIG)
+        driver.run(expect_emits: 1, timeout: 5) do
+            send_trap_v2()
+        end
+
+        assert_equal(driver.events.length(), 1)
+        driver.events.each do |tag, timestamp, trap_events|
+            assert_equal 'SNMPTrap.Alert', tag
+            assert_true timestamp.is_a?(Fluent::EventTime)
+            message = trap_events.to_s
+            message = message.delete('\\"')
+            assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, message)
+
+            trap_events.each do |key, value|
+                assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host))/, key.to_s, "Unknown OID format")
+            end
+        end
+    end
 end

--- a/test/plugin/test_in_snmptrapalert.rb
+++ b/test/plugin/test_in_snmptrapalert.rb
@@ -61,7 +61,7 @@ class SnmptrapalertInputTest < Test::Unit::TestCase
         driver.events.each do |tag, timestamp, trap_events|
             assert_equal("SNMPTrap.Alert", tag)
             assert_true(timestamp.is_a?(Fluent::EventTime))
-            assert_equal(trap_events, {"SNMPv2-SMI::mgmt.3.4"=>"1", "enterprise"=>[1,3,6,1,4,1,10300,1,1,1,12],"host"=>"127.0.0.1", "specific_trap"=>0})
+            assert_equal(trap_events, {"SNMPv2-SMI::mgmt.3.4"=>"1", "enterprise"=>[1,3,6,1,4,1,10300,1,1,1,12],"generic_trap"=>:enterpriseSpecific, "host"=>"127.0.0.1", "specific_trap"=>0})
         end
     end
 
@@ -80,7 +80,7 @@ class SnmptrapalertInputTest < Test::Unit::TestCase
             assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, message)
 
             trap_events.each do |key, value|
-                assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host)|(specific_trap)|(enterprise))/, key.to_s, "Unknown OID format")
+                assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host)|(specific_trap)|(enterprise)|(generic_trap))/, key.to_s, "Unknown OID format")
             end
         end
     end

--- a/test/plugin/test_in_snmptrapalert.rb
+++ b/test/plugin/test_in_snmptrapalert.rb
@@ -28,13 +28,14 @@ class SnmptrapalertInputTest < Test::Unit::TestCase
     end
   end
 
-#   def send_trap_v2()
-#     SNMP::Manager.open(:Host => "127.0.0.1",:Version => :SNMPv2) do |snmp|
-#       snmp.trap_v2(
-#         "", #Empty string for requestID
-#         [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(1))])
-#     end
-#   end
+  def send_trap_v2()
+    SNMP::Manager.open(:Host => "127.0.0.1",:Version => :SNMPv2c) do |snmp|
+      snmp.trap_v2(
+          400, # Fake system up time of 4 seconds
+        "1.3.6.1.4.1.10300.1.1.1.12",
+        [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(1))])
+    end
+  end
 
   def test_configure
     driver = create_driver('')
@@ -74,34 +75,34 @@ class SnmptrapalertInputTest < Test::Unit::TestCase
     end
   end
 
-#   test 'emitv2' do
-#     driver = create_driver(SNMP_CONFIG)
-#     driver.run(expect_emits: 1, timeout: 5) do
-#       send_trap_v2()
-#     end
+  test 'emitv2' do
+    driver = create_driver(SNMP_CONFIG)
+    driver.run(expect_emits: 1, timeout: 5) do
+      send_trap_v2()
+    end
 
-#     driver.events.each do |tag, timestamp, trap_events|
-#       assert_equal("SNMPTrap.Alert", tag)
-#       assert_true(timestamp.is_a?(Fluent::EventTime))
-#       assert_equal(trap_events, {"SNMPv2-SMI::mgmt.3.4"=>"1", "host"=>"127.0.0.1"})
-#     end
-#   end
+    driver.events.each do |tag, timestamp, trap_events|
+      assert_equal("SNMPTrap.Alert", tag)
+      assert_true(timestamp.is_a?(Fluent::EventTime))
+      assert_equal(trap_events, {"SNMPv2-MIB::snmpTrapOID.0"=>"SNMPv2-SMI::enterprises.10300.1.1.1.12", "SNMPv2-MIB::sysUpTime.0"=>"00:00:04.00","SNMPv2-SMI::mgmt.3.4"=>"1", "host"=>"127.0.0.1"})
+    end
+  end
 
-#   test 'emit_mibv2' do
-#     driver = create_driver(SNMP_CONFIG)
-#     driver.run(expect_emits: 1, timeout: 5) do
-#       send_trap_v2()
-#     end
-#     driver.events.each do |tag, timestamp, trap_events|
-#       assert_equal 'SNMPTrap.Alert', tag
-#       assert_true timestamp.is_a?(Fluent::EventTime)
-#       message = trap_events.to_s
-#       message = message.delete('\\"')
-#       assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, message)
+  test 'emit_mibv2' do
+    driver = create_driver(SNMP_CONFIG)
+    driver.run(expect_emits: 1, timeout: 5) do
+      send_trap_v2()
+    end
+    driver.events.each do |tag, timestamp, trap_events|
+      assert_equal 'SNMPTrap.Alert', tag
+      assert_true timestamp.is_a?(Fluent::EventTime)
+      message = trap_events.to_s
+      message = message.delete('\\"')
+      assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, message)
 
-#       trap_events.each do |key, value|
-#         assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host))/, key.to_s, "Unknown OID format")
-#       end
-#     end
-#   end
+      trap_events.each do |key, value|
+        assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host))/, key.to_s, "Unknown OID format")
+      end
+    end
+  end
 end

--- a/test/plugin/test_in_snmptrapalert.rb
+++ b/test/plugin/test_in_snmptrapalert.rb
@@ -2,77 +2,106 @@ require 'helper'
 
 class SnmptrapalertInputTest < Test::Unit::TestCase
 
-    setup do
-        Fluent::Test.setup
+  setup do
+    Fluent::Test.setup
+  end
+
+  SNMP_CONFIG = %[
+    host 0.0.0.0
+    port 162
+    tag SNMPTrap.Alert
+  ]
+
+  def create_driver(conf=CONFIG)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::SnmpTrapAlert).configure(conf)
+  end
+
+  def send_trap_v1()
+    SNMP::Manager.open(:Host => "127.0.0.1",:Version => :SNMPv1) do |snmp|
+      snmp.trap_v1(
+        "1.3.6.1.4.1.10300.1.1.1.12",
+        '172.0.0.1',
+        :enterpriseSpecific, #Generic Trap Type
+        0,
+        1234,
+        [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(1))])
+    end
+  end
+
+#   def send_trap_v2()
+#     SNMP::Manager.open(:Host => "127.0.0.1",:Version => :SNMPv2) do |snmp|
+#       snmp.trap_v2(
+#         "", #Empty string for requestID
+#         [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(1))])
+#     end
+#   end
+
+  def test_configure
+    driver = create_driver('')
+    assert_equal "0.0.0.0", driver.instance.host
+    assert_equal 162, driver.instance.port
+    assert_equal 'SNMPTrap.Alert', driver.instance.tag
+  end
+
+  test 'emitv1' do
+    driver = create_driver(SNMP_CONFIG)
+    driver.run(expect_emits: 1, timeout: 5) do
+      send_trap_v1()
     end
 
-    SNMP_CONFIG = %[
-        host 0.0.0.0
-        port 1620
-        tag SNMPTrap.Alert
-    ]
-
-    def create_driver(conf=SNMP_CONFIG)
-        Fluent::Test::Driver::Input.new(Fluent::Plugin::SnmpTrapAlert).configure(conf)
+    driver.events.each do |tag, timestamp, trap_events|
+      assert_equal("SNMPTrap.Alert", tag)
+      assert_true(timestamp.is_a?(Fluent::EventTime))
+      assert_equal(trap_events, {"SNMPv2-SMI::mgmt.3.4"=>"1", "enterprise"=>[1,3,6,1,4,1,10300,1,1,1,12],"host"=>"127.0.0.1", "specific_trap"=>0})
     end
+  end
 
-    def send_trap()
-        SNMP::Manager.open(:Host => "127.0.0.1", :TrapPort => 1620, :Version => :SNMPv1) do |snmp|
-            snmp.trap_v1(
-            "1.3.6.1.4.1.10300.1.1.1.12",
-            '172.0.0.1',
-            :enterpriseSpecific, #Generic Trap Type
-            0,
-            1234,
-            [SNMP::VarBind.new("1.3.6.1.2.3.4", SNMP::Integer.new(1))])
-        end
+  test 'emit_mibv1' do
+    driver = create_driver(SNMP_CONFIG)
+    driver.run(expect_emits: 1, timeout: 5) do
+      send_trap_v1()
     end
+    driver.events.each do |tag, timestamp, trap_events|
+      assert_equal 'SNMPTrap.Alert', tag
+      assert_true timestamp.is_a?(Fluent::EventTime)
+      message = trap_events.to_s
+      message = message.delete('\\"')
+      assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, message)
 
-    def test_configure
-        driver = create_driver('')
-        assert_equal "0.0.0.0", driver.instance.host
-        assert_equal 162, driver.instance.port
-        assert_equal 'SNMPTrap.Alert', driver.instance.tag
+      trap_events.each do |key, value|
+        assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host)|(specific_trap)|(enterprise))/, key.to_s, "Unknown OID format")
+      end
     end
+  end
 
-    def test_configure_custom
-        driver = create_driver(SNMP_CONFIG)
-        assert_equal "0.0.0.0", driver.instance.host
-        assert_equal 1620, driver.instance.port
-        assert_equal 'SNMPTrap.Alert', driver.instance.tag
-    end
+#   test 'emitv2' do
+#     driver = create_driver(SNMP_CONFIG)
+#     driver.run(expect_emits: 1, timeout: 5) do
+#       send_trap_v2()
+#     end
 
-    test 'emit' do
-        driver = create_driver(SNMP_CONFIG)
-        driver.run(expect_emits: 1, timeout: 5) do
-            send_trap()
-        end
+#     driver.events.each do |tag, timestamp, trap_events|
+#       assert_equal("SNMPTrap.Alert", tag)
+#       assert_true(timestamp.is_a?(Fluent::EventTime))
+#       assert_equal(trap_events, {"SNMPv2-SMI::mgmt.3.4"=>"1", "host"=>"127.0.0.1"})
+#     end
+#   end
 
-        assert_equal(driver.events.length(), 1)
-        driver.events.each do |tag, timestamp, trap_events|
-            assert_equal("SNMPTrap.Alert", tag)
-            assert_true(timestamp.is_a?(Fluent::EventTime))
-            assert_equal(trap_events, {"SNMPv2-SMI::mgmt.3.4"=>"1", "host"=>"127.0.0.1"})
-        end
-    end
+#   test 'emit_mibv2' do
+#     driver = create_driver(SNMP_CONFIG)
+#     driver.run(expect_emits: 1, timeout: 5) do
+#       send_trap_v2()
+#     end
+#     driver.events.each do |tag, timestamp, trap_events|
+#       assert_equal 'SNMPTrap.Alert', tag
+#       assert_true timestamp.is_a?(Fluent::EventTime)
+#       message = trap_events.to_s
+#       message = message.delete('\\"')
+#       assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, message)
 
-    test 'emit_mib' do
-        driver = create_driver(SNMP_CONFIG)
-        driver.run(expect_emits: 1, timeout: 5) do
-            send_trap()
-        end
-
-        assert_equal(driver.events.length(), 1)
-        driver.events.each do |tag, timestamp, trap_events|
-            assert_equal 'SNMPTrap.Alert', tag
-            assert_true timestamp.is_a?(Fluent::EventTime)
-            message = trap_events.to_s
-            message = message.delete('\\"')
-            assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, message)
-
-            trap_events.each do |key, value|
-                assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host))/, key.to_s, "Unknown OID format")
-            end
-        end
-    end
+#       trap_events.each do |key, value|
+#         assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host))/, key.to_s, "Unknown OID format")
+#       end
+#     end
+#   end
 end


### PR DESCRIPTION
For an snmp trap of v2 or newer, the oid or Object Identifier is sent in the `var_bind` for V1, the trap is split into 2 parts. The unique way to identify a trap is done by the combination of the `specific_trap` , `enterprise`, and `generic_trap` fields. Without these field being passed through in this plugin, we cannot get the identifier of the trap.