### PR TITLE
Adding agent_addr field to SNMPv1 trap

### DIFF
--- a/lib/fluent/plugin/in_snmptrapalert.rb
+++ b/lib/fluent/plugin/in_snmptrapalert.rb
@@ -97,6 +97,7 @@ module Fluent
                                 trap_events['specific_trap'] = trap.specific_trap
                                 trap_events['enterprise'] = trap.enterprise
                                 trap_events['generic_trap'] = trap.generic_trap
+                                trap_events['agent_addr'] = trap.agent_addr.to_s
                             end
                             if @trap_format == 'tojson'
                                require 'json'

--- a/test/plugin/test_in_snmptrapalert.rb
+++ b/test/plugin/test_in_snmptrapalert.rb
@@ -61,7 +61,7 @@ class SnmptrapalertInputTest < Test::Unit::TestCase
         driver.events.each do |tag, timestamp, trap_events|
             assert_equal("SNMPTrap.Alert", tag)
             assert_true(timestamp.is_a?(Fluent::EventTime))
-            assert_equal(trap_events, {"SNMPv2-SMI::mgmt.3.4"=>"1", "enterprise"=>[1,3,6,1,4,1,10300,1,1,1,12],"generic_trap"=>:enterpriseSpecific, "host"=>"127.0.0.1", "specific_trap"=>0})
+            assert_equal(trap_events, {"SNMPv2-SMI::mgmt.3.4"=>"1", "enterprise"=>[1,3,6,1,4,1,10300,1,1,1,12],"generic_trap"=>:enterpriseSpecific, "host"=>"127.0.0.1", "specific_trap"=>0, "agent_addr"=>"172.0.0.1"})
         end
     end
 
@@ -80,7 +80,7 @@ class SnmptrapalertInputTest < Test::Unit::TestCase
             assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, message)
 
             trap_events.each do |key, value|
-                assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host)|(specific_trap)|(enterprise)|(generic_trap))/, key.to_s, "Unknown OID format")
+                assert_match(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13})|(host)|(specific_trap)|(enterprise)|(generic_trap)|(agent_addr))/, key.to_s, "Unknown OID format")
             end
         end
     end


### PR DESCRIPTION
Adding "agent_addr" field to trap_events dict for SNMPv1 traps. It is used to identify ip address of original device if we are routing packet via one or more hops.