### PR TITLE
Upgrade bundler & references to version 2.2.10 or later to mitigate vulnerability

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,6 +21,6 @@ jobs:
         ruby-version: 2.6.x
     - name: Build and test with Rake
       run: |
-        gem install bundler:1.14
+        gem install bundler:2.2.10
         bundle install --jobs 4 --retry 3 --path vendor/bundle
         bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ $ docker run -it --rm -v $PWD:/code ubuntu:16.04 bash
 $ apt-get update && apt-get install -y --no-install-recommends ruby-dev git gcc make libc6-dev smitools
 $ cd code
 $ gem install bundler:2.2.10
-$ bundle install --path vendor/bundle
+$ bundle config set --local path 'vendor/bundle'
+$ bundle install
 $ bundle exec rake test
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 $ docker run -it --rm -v $PWD:/code ubuntu:16.04 bash
 $ apt-get update && apt-get install -y --no-install-recommends ruby-dev git gcc make libc6-dev smitools
 $ cd code
-$ gem install bundler:1.14
+$ gem install bundler:2.2.10
 $ bundle install --path vendor/bundle
 $ bundle exec rake test
 ```

--- a/fluent-plugin-snmptrapalert.gemspec
+++ b/fluent-plugin-snmptrapalert.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]


### PR DESCRIPTION
**Change:** Fix https://github.com/advisories/GHSA-fp4w-jxhp-m23p

**Testing:** Deployed built image referencing this brach to an environment with SNMP telemetry; verified presence of end-to-end telemetry and no errors